### PR TITLE
Enable proxy support for HTTPGET Tasks.

### DIFF
--- a/build.default.properties
+++ b/build.default.properties
@@ -43,3 +43,6 @@ csslint.rules = empty-rules,display-property-grouping,zero-units,vendor-prefix,g
 
 # The url from where to download rhino
 rhino.url = http://ftp.mozilla.org/pub/mozilla.org/js/rhino1_7R3.zip
+
+# Set this variable to enable the httpget proxy.
+# httpget.proxy = http://localhost:3128/

--- a/build.default.properties
+++ b/build.default.properties
@@ -7,6 +7,11 @@ drupal.version = 7
 # The install profile to use
 drupal.profile = standard
 
+# If you set this variable, the RewriteBase directive in Drupal's .htaccess will be enabled.
+# If not set, Phing will not alter it.
+# Ex: drupal.rewritebase = /drupal7 
+# drupal.rewritebase = 
+
 # The database url to use for site installs
 db.url = sqlite:${project.basedir}/database.sqlite
 

--- a/build.xml
+++ b/build.xml
@@ -226,7 +226,8 @@ parent `lint-js` tasks. -->
       <param value="${jslint4java.url}" />
     </php>
     <httpget url="${jslint4java.url}"
-             dir="${jslint4java.dir}"/>
+             dir="${jslint4java.dir}"
+             proxy="${httpget.proxy}"/>
     <unzip file="${jslint4java.dir}/${jslint4java.zipfile}"
            todir="${jslint4java.dir}" />
 
@@ -978,8 +979,9 @@ Configuration of which installation profile and database to use in done in
      <php function="basename" returnProperty="rhino.zipfile">
        <param value="${rhino.url}" />
      </php>
-     <httpget url="${rhino.url}"
-              dir="${rhino.dir}"/>
+    <httpget url="${jslint4java.url}"
+             dir="${jslint4java.dir}"
+             proxy="${httpget.proxy}"/>
      <unzip file="${rhino.dir}/${rhino.zipfile}"
             todir="${rhino.dir}" />
 


### PR DESCRIPTION
Now that support for proxy has been included in HttpGet Task (see: https://github.com/phingofficial/phing/pull/70), we can add a new option in build.xml to enable the proxy.

Without this, I cannot get it working in my company and I suppose that I'm not the only one.
