### PR TITLE
Allow deploying sites via Aegir (not just drush site-install)

### DIFF
--- a/build.default.properties
+++ b/build.default.properties
@@ -26,6 +26,20 @@ drupal.db.url = sqlite:${project.drupal.dir}/database.sqlite
 # Ex: drupal.make.rewritebase = /drupal7
 # drupal.make.rewritebase =
 
+# How to deploy the site during 'phing site-install'.
+# Options include: drush, aegir
+deploy.type = drush
+
+# Options for a Drush-based deployment
+# The database url to use for site installs
+deploy.drush.db = sqlite:${project.drupal.dir}/database.sqlite
+
+# Options for an Aegir-based deployment
+# The site name to use for the site (also, the domain name it'll be accessible under)
+deploy.aegir.site = my-site.localhost
+# The machine name to use for the platform (by default: phing.project.name)
+#deploy.aegir.platform = my_platform
+
 # The directory containing the modules and themes for the project relative to the drupal root directory. If using Drush Make this is also where modules, themes, libraries etc. will be downloaded to.
 project.code.dir = sites/all
 # A common prefix for modules developed for the site e.g. your_prefix_your_module

--- a/build.default.properties
+++ b/build.default.properties
@@ -41,6 +41,12 @@ deploy.aegir.site = phing-site.localhost
 deploy.aegir.platform = phing_platform
 # The machine name to use for the server
 deploy.aegir.server = localhost
+# The drush command to use for Aegir. This is useful if your Aegir install uses
+# a different Drush command than the default, for example, you run Aegir 1.x
+# with uses Drush 4, but you want everything else to use Drush 6.
+deploy.aegir.drush = drush
+# This would change the default drush
+# drush.bin = drush6
 
 # The directory containing the modules and themes for the project relative to the drupal root directory. If using Drush Make this is also where modules, themes, libraries etc. will be downloaded to.
 project.code.dir = sites/all

--- a/build.default.properties
+++ b/build.default.properties
@@ -36,9 +36,11 @@ deploy.drush.db = sqlite:${project.drupal.dir}/database.sqlite
 
 # Options for an Aegir-based deployment
 # The site name to use for the site (also, the domain name it'll be accessible under)
-deploy.aegir.site = my-site.localhost
-# The machine name to use for the platform (by default: phing.project.name)
-#deploy.aegir.platform = my_platform
+deploy.aegir.site = phing-site.localhost
+# The machine name to use for the platform
+deploy.aegir.platform = phing_platform
+# The machine name to use for the server
+deploy.aegir.server = localhost
 
 # The directory containing the modules and themes for the project relative to the drupal root directory. If using Drush Make this is also where modules, themes, libraries etc. will be downloaded to.
 project.code.dir = sites/all

--- a/build.xml
+++ b/build.xml
@@ -582,7 +582,7 @@ coder-review-d7.
 No need to run `init` here. This target should only be called from parent
 `coder-review-*` targets. -->
   <target name="coder-review"
-          depends="setup-phing-drush">
+          depends="setup-phing-drush, deploy">
     <!-- Get a list of modules and themes matching the project prefix.
          These are the ones we are going to review. -->
     <drush command="pm-list" pipe="true" returnProperty="projects" />
@@ -1138,6 +1138,16 @@ Configuration of which installation profile and how to deploy are in done in
         <equals arg1="${deploy.type}" arg2="aegir"/>
         <then>
           <phingcall target="deploy-aegir" />
+
+          <!-- Now that the site is installed, we need to set drush.uri so that drush
+               commands against the site succeeed. 
+
+               TODO: this really should set drush.alias so that more complex Aegir
+               configurations will work, but that isn't yet supported:
+
+                 https://drupal.org/node/2139219
+            -->
+          <property name="drush.uri" value="${drupal.uri}"/>
         </then>
       </elseif>
 
@@ -1220,7 +1230,6 @@ It will use the platform and site names specified in `build.properties`. -->
         </drush>
       </then>
     </if>
-     
 
     <!-- Set property to prevent target from being executed multiple times -->
     <property name="project.deployed.aegir" value="true"/>
@@ -1253,7 +1262,7 @@ It will use the platform name specified in `build.properties`. -->
 
   <!-- ### Download and enable a project/module -->
   <target name="enable-module"
-          depends="setup-phing-drush">
+          depends="setup-phing-drush, deploy">
     <!-- If project is not set then we assume that the module name is also
          the project name. -->
     <property name="project" value="${module}" override="no"/>

--- a/build.xml
+++ b/build.xml
@@ -1157,6 +1157,11 @@ This is an alias for 'deploy' provided for backward compatibility.
 Please use 'deploy' instead! -->
   <target name="site-install" depends="deploy" hidden="true" />
 
+<!-- ### Deploy a Drupal site via Drush
+
+This will install the Drupal site via 'drush site-install'.
+
+It will use the database credentials specified in `build.properties`. -->
   <target name="deploy-drush"
           depends="init, setup-phing-drush"
           unless="project.deployed.drush">
@@ -1174,6 +1179,87 @@ Please use 'deploy' instead! -->
 
     <!-- Set property to prevent target from being executed multiple times -->
     <property name="project.deployed.drush" value="true"/>
+  </target>
+
+<!-- ### Deploy a Drupal site via Aegir
+
+This will install the Drupal site via Aegir.
+
+It will use the platform and site names specified in `build.properties`. -->
+  <target name="deploy-aegir"
+          depends="init, setup-phing-drush, aegir-create-platform"
+          unless="project.deployed.aegir">
+    
+    <if>
+      <not>
+        <available file="~/.drush/platform_${deploy.aegir.site}.alias.drushrc.php"/>
+      </not>
+      <then>
+        <drush command="provision-save" root="">
+          <param>@${deploy.aegir.site}</param>
+          <option name="context_type">site</option>
+          <option name="uri">${deploy.aegir.site}</option>
+          <option name="platform">@platform_${deploy.aegir.platform}</option>
+          <option name="server">@server_${deploy.aegir.server}</option>
+          <option name="db_server">@server_${deploy.aegir.server}</option>
+          <option name="profile">${drupal.profile}</option>
+          <option name="client_name">admin</option>
+        </drush>
+
+        <!-- TODO: drush should support an alias="..." attribute! -->
+        <drush command="@${deploy.aegir.site} provision-install" root="">
+        </drush>
+
+        <!-- TODO: drush should support an alias="..." attribute! -->
+        <drush command="@hostmaster hosting-task" root="">
+          <param>@platform_${deploy.aegir.platform}</param>
+          <param>verify</param>
+        </drush>
+
+        <!-- TODO: drush should support an alias="..." attribute! -->
+        <drush command="@hostmaster hosting-dispatch" root="">
+        </drush>
+
+        <!-- TODO: drush should support an alias="..." attribute! -->
+        <drush command="@hostmaster hosting-task" root="">
+          <param>@${deploy.aegir.site}</param>
+          <param>verify</param>
+        </drush>
+      </then>
+    </if>
+     
+
+    <!-- Set property to prevent target from being executed multiple times -->
+    <property name="project.deployed.aegir" value="true"/>
+  </target>
+
+<!-- ### Create an Aegir platform
+
+This will register the Drupal site with Aegir as a platform.
+
+It will use the platform name specified in `build.properties`. -->
+  <target name="aegir-create-platform"
+          depends="init, setup-phing-drush">
+    <if>
+      <not>
+        <available file="~/.drush/platform_${deploy.aegir.platform}.alias.drushrc.php"/>
+      </not>
+      <then>
+        <drush command="provision-save" assume="yes" root="${project.drupal.dir}">
+          <param>@platform_${deploy.aegir.platform}</param>
+          <option name="context_type">platform</option>
+        </drush>
+        
+        <!-- TODO: drush should support an alias="..." attribute! -->
+        <drush command="@hostmaster hosting-import" root="">
+          <param>@platform_${deploy.aegir.platform}</param>
+        </drush>
+
+        <!-- TODO: drush should support an alias="..." attribute! -->
+        <drush command="@hostmaster hosting-dispatch" root="">
+        </drush>
+      </then>
+    </if>
   </target>
 
   <!-- ### Download and enable a project/module -->

--- a/build.xml
+++ b/build.xml
@@ -619,10 +619,10 @@ No need to run `init` here. This target should only be called from parent
     <!-- Execute coder review and output results in XML format-->
     <drush command="${coder.review.command}" assume="yes"
            pipe="yes" returnProperty="xml">
-      <param>no-empty</param>
-      <param>checkstyle</param>
-      <param>minor</param>
-      <param>${coder.review.type}</param>
+      <option name="no-empty"/>
+      <option name="checkstyle"/>
+      <option name="minor"/>
+      <option name="${coder.review.type}"/>
       <!-- Review all the modules and themes matching the project prefix -->
       <param>${project.code.projects}</param>
       <!-- Review additional modules which do not match the prefix -->
@@ -1137,7 +1137,9 @@ Configuration of which installation profile and how to deploy are in done in
       <elseif>
         <equals arg1="${deploy.type}" arg2="aegir"/>
         <then>
-          <phingcall target="deploy-aegir" />
+          <phingcall target="deploy-aegir">
+            <property name="drush.bin" value="${deploy.aegir.drush}"/>
+          </phingcall>
 
           <!-- Now that the site is installed, we need to set drush.uri so that drush
                commands against the site succeeed. 

--- a/build.xml
+++ b/build.xml
@@ -556,7 +556,7 @@ specific prefix. -->
 
   <target name="coder-review-d7"
           description="Review code using Drupal 7 Coder module"
-          depends="init, clean, site-install">
+          depends="init, clean, deploy">
     <!-- Setup properties for running Coder Review.
          For some reason these properties are not passed correctly through to
          subtargets when defining them within the phingcall. -->
@@ -686,7 +686,7 @@ Execution of this target can be skipped by setting the
 -->
   <target name="simpletest"
           description="Run all unit tests"
-          depends="init, setup-phing-drush, site-install"
+          depends="init, setup-phing-drush, deploy"
           unless="project.simpletest.skip">
     <!-- Enable simpletest module. If using Drupal 6 the module will be
          downloaded as well. -->
@@ -1118,17 +1118,50 @@ called from `init` target. -->
     <property name="project.cleaned" value="true"/>
   </target>
 
-<!-- ### Install a Drupal site
+<!-- ### Deploy a Drupal site
 
-This initializes a Drupal site using a installation profile.
+This will install a Drupal site for a given installation profile.
 
-Configuration of which installation profile and database to use in done in
+Configuration of which installation profile and how to deploy are in done in
 `build.properties`. -->
-  <target name="site-install"
+  <target name="deploy"
           depends="init, setup-phing-drush"
           unless="project.installed">
+
+    <if>
+      <equals arg1="${deploy.type}" arg2="drush"/>
+      <then>
+        <phingcall target="deploy-drush" />
+      </then>
+
+      <elseif>
+        <equals arg1="${deploy.type}" arg2="aegir"/>
+        <then>
+          <phingcall target="deploy-aegir" />
+        </then>
+      </elseif>
+
+      <else>
+        <fail msg="Unknown deploy.type = ${deploy.type}" />
+      </else>
+    </if>
+
+    <!-- Set property to prevent target from being executed multiple times -->
+    <property name="project.installed" value="true"/>
+  </target>
+
+<!-- ### (deprecated) Deploy a Drupal site
+
+This is an alias for 'deploy' provided for backward compatibility.
+
+Please use 'deploy' instead! -->
+  <target name="site-install" depends="deploy" hidden="true" />
+
+  <target name="deploy-drush"
+          depends="init, setup-phing-drush"
+          unless="project.deployed.drush">
     <drush command="site-install" assume="yes">
-      <option name="db-url">${drupal.db.url}</option>
+      <option name="db-url">${deploy.drush.db}</option>
       <param>${drupal.profile}</param>
     </drush>
     <!-- Fix permissions for the default site directory and settings. The
@@ -1140,7 +1173,7 @@ Configuration of which installation profile and database to use in done in
            mode="0755" failonerror="true"/>
 
     <!-- Set property to prevent target from being executed multiple times -->
-    <property name="project.installed" value="true"/>
+    <property name="project.deployed.drush" value="true"/>
   </target>
 
   <!-- ### Download and enable a project/module -->

--- a/build.xml
+++ b/build.xml
@@ -1192,11 +1192,10 @@ It will use the platform and site names specified in `build.properties`. -->
     
     <if>
       <not>
-        <available file="~/.drush/platform_${deploy.aegir.site}.alias.drushrc.php"/>
+        <available file="${user.home}/.drush/${deploy.aegir.site}.alias.drushrc.php"/>
       </not>
       <then>
-        <drush command="provision-save" root="">
-          <param>@${deploy.aegir.site}</param>
+        <drush command="provision-save" root="" alias="@${deploy.aegir.site}">
           <option name="context_type">site</option>
           <option name="uri">${deploy.aegir.site}</option>
           <option name="platform">@platform_${deploy.aegir.platform}</option>
@@ -1206,22 +1205,16 @@ It will use the platform and site names specified in `build.properties`. -->
           <option name="client_name">admin</option>
         </drush>
 
-        <!-- TODO: drush should support an alias="..." attribute! -->
-        <drush command="@${deploy.aegir.site} provision-install" root="">
-        </drush>
+        <drush command="provision-install" root="" alias="@${deploy.aegir.site}" />
 
-        <!-- TODO: drush should support an alias="..." attribute! -->
-        <drush command="@hostmaster hosting-task" root="">
+        <drush command="hosting-task" root="" alias="@hostmaster">
           <param>@platform_${deploy.aegir.platform}</param>
           <param>verify</param>
         </drush>
 
-        <!-- TODO: drush should support an alias="..." attribute! -->
-        <drush command="@hostmaster hosting-dispatch" root="">
-        </drush>
+        <drush command="hosting-dispatch" root="" alias="@hostmaster" />
 
-        <!-- TODO: drush should support an alias="..." attribute! -->
-        <drush command="@hostmaster hosting-task" root="">
+        <drush command="hosting-task" root="" alias="@hostmaster">
           <param>@${deploy.aegir.site}</param>
           <param>verify</param>
         </drush>
@@ -1242,22 +1235,18 @@ It will use the platform name specified in `build.properties`. -->
           depends="init, setup-phing-drush">
     <if>
       <not>
-        <available file="~/.drush/platform_${deploy.aegir.platform}.alias.drushrc.php"/>
+        <available file="${user.home}/.drush/platform_${deploy.aegir.platform}.alias.drushrc.php"/>
       </not>
       <then>
-        <drush command="provision-save" assume="yes" root="${project.drupal.dir}">
-          <param>@platform_${deploy.aegir.platform}</param>
+        <drush command="provision-save" root="${project.drupal.dir}" alias="@platform_${deploy.aegir.platform}">
           <option name="context_type">platform</option>
         </drush>
         
-        <!-- TODO: drush should support an alias="..." attribute! -->
-        <drush command="@hostmaster hosting-import" root="">
+        <drush command="hosting-import" root="" alias="@hostmaster">
           <param>@platform_${deploy.aegir.platform}</param>
         </drush>
 
-        <!-- TODO: drush should support an alias="..." attribute! -->
-        <drush command="@hostmaster hosting-dispatch" root="">
-        </drush>
+        <drush command="hosting-dispatch" root="" alias="@hostmaster" />
       </then>
     </if>
   </target>

--- a/build.xml
+++ b/build.xml
@@ -565,7 +565,7 @@ specific prefix. -->
     <!-- Download and enable the Coder Review module -->
     <phingcall target="enable-module">
       <property name="project" value="coder"/>
-      <property name="project.version" value="7.x-1.0"/>
+      <property name="project.version" value="7.x-2.0"/>
       <property name="module" value="coder_review"/>
     </phingcall>
 


### PR DESCRIPTION
The current build.xml provides a "site-install" target which uses "drush site-install" to install the site.

This pull request converts "site-install" to "deploy" and allows you to choose in the build.properties which "deploy.type" you would like - either: drush or aegir. (Note: the "site-install" target is retained as an alias to deploy.)

I could envision even deploying to Pantheon or something else interesting in the future! :-)
